### PR TITLE
Bug/email check 18

### DIFF
--- a/api/user_api.go
+++ b/api/user_api.go
@@ -4,6 +4,7 @@ import (
 	"bizCard/application"
 	"bizCard/domain"
 	"bizCard/util"
+	"errors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -16,6 +17,9 @@ func RegisterUser(c *gin.Context) {
 		c.JSON(500, result)
 	}
 	data := application.UserServiceBean.RegisterUser(userRegister)
+	if data.Present == false {
+		c.JSON(500, errors.New("user register fail"))
+	}
 	result.Data = data
 	c.JSON(200, result)
 }
@@ -29,6 +33,11 @@ func LoginUser(c *gin.Context) {
 		c.JSON(500, result)
 	}
 	data, id := application.UserServiceBean.LoginUser(userLoginForm)
+
+	if data.Present == false {
+		c.JSON(500, errors.New("Login Fail"))
+	}
+
 	token, err := util.CreateJwt(data, id)
 	if err != nil {
 		result = domain.Fail()

--- a/api/user_api_test.go
+++ b/api/user_api_test.go
@@ -74,6 +74,15 @@ func (ets *UserApiTestSuite) TestRegisterUser() {
 		Path("$.data.name").Equal("test")
 }
 
+func (ets *UserApiTestSuite) TestRegisterUser_error() {
+	ets.UserService.On("RegisterUser", mock.Anything).Return(domain.UserInfo{Present: false})
+	ets.E.POST("/user/register").
+		WithHeader("Content-Type", "application/json").
+		WithJSON(ets.Data).
+		Expect().
+		Status(500)
+}
+
 func (ets *UserApiTestSuite) TestLoginUser() {
 	ets.UserService.On("LoginUser", mock.Anything).Return(ets.UserInfo, 1)
 	ets.E.POST("/user/login").
@@ -83,6 +92,15 @@ func (ets *UserApiTestSuite) TestLoginUser() {
 		Status(200).
 		JSON().
 		Path("$.data.name").Equal("test")
+}
+
+func (ets *UserApiTestSuite) TestLoginUser_error() {
+	ets.UserService.On("LoginUser", mock.Anything).Return(domain.UserInfo{Present: false}, 0)
+	ets.E.POST("/user/login").
+		WithHeader("Content-Type", "application/json").
+		WithJSON(ets.Data).
+		Expect().
+		Status(500)
 }
 
 func TestUserApiTestSuite(t *testing.T) {

--- a/application/UserServiceImpl.go
+++ b/application/UserServiceImpl.go
@@ -28,6 +28,13 @@ func (userServiceImpl *UserServiceImpl) LoginUser(loginForm domain.UserLoginForm
 }
 
 func (userServiceImpl *UserServiceImpl) RegisterUser(userRegister domain.UserRegister) domain.UserInfo {
+	_, err := userServiceImpl.UserRepository.FindUser(userRegister.Email)
+	if err == nil {
+		return domain.UserInfo{
+			Present: false,
+		}
+	}
+
 	encryptPassword, err := util.GenerateBcrypt(userRegister.Password)
 	if err != nil {
 		log.Println(err)

--- a/application/UserServiceImpl_test.go
+++ b/application/UserServiceImpl_test.go
@@ -36,9 +36,17 @@ func (ets *UserServiceTestSuite) SetupTest() {
 	ets.UserService = &application.UserServiceImpl{UserRepository: &ets.UserRepository}
 }
 func (ets *UserServiceTestSuite) TestUserServiceImpl_RegisterUser() {
+	ets.UserRepository.On("FindUser", mock.AnythingOfType("string")).Return(ent.User{Email: ""}, nil)
 	ets.UserRepository.On("RegisterUser", mock.Anything).Return(ets.User, nil)
 	result := ets.UserService.RegisterUser(ets.UserRegister)
 	ets.Equal("tester", result.Name)
+}
+
+func (ets *UserServiceTestSuite) TestUserServiceImpl_RegisterUser_Email_Exist() {
+	ets.UserRepository.On("FindUser", mock.AnythingOfType("string")).Return(ent.User{}, nil)
+	ets.UserRepository.On("RegisterUser", mock.Anything).Return(ets.User, nil)
+	result := ets.UserService.RegisterUser(ets.UserRegister)
+	ets.Equal(false, result.Present)
 }
 
 func (ets *UserServiceTestSuite) TestUserServiceImpl_FindUser() {

--- a/application/UserServiceImpl_test.go
+++ b/application/UserServiceImpl_test.go
@@ -5,6 +5,7 @@ import (
 	"bizCard/domain"
 	"bizCard/ent"
 	mockrepo "bizCard/mock/repository"
+	"errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -36,7 +37,7 @@ func (ets *UserServiceTestSuite) SetupTest() {
 	ets.UserService = &application.UserServiceImpl{UserRepository: &ets.UserRepository}
 }
 func (ets *UserServiceTestSuite) TestUserServiceImpl_RegisterUser() {
-	ets.UserRepository.On("FindUser", mock.AnythingOfType("string")).Return(ent.User{Email: ""}, nil)
+	ets.UserRepository.On("FindUser", mock.AnythingOfType("string")).Return(ent.User{Email: ""}, errors.New("user not found"))
 	ets.UserRepository.On("RegisterUser", mock.Anything).Return(ets.User, nil)
 	result := ets.UserService.RegisterUser(ets.UserRegister)
 	ets.Equal("tester", result.Name)


### PR DESCRIPTION
## 개요
- 유저 등록 시, 이메일 중복 체크하는 부분이 없음
## 작업사항
- 유저 등록 시, 이메일 중보 체크하는 코드 추가
## 변경로직
- RegisterUser에서 이메일을 체크하는 코드 추가
- err에 관련한 반환 코드 구현
### 변경전
- RegisterUser
```go
func (userServiceImpl *UserServiceImpl) RegisterUser(userRegister domain.UserRegister) domain.UserInfo {
	encryptPassword, err := util.GenerateBcrypt(userRegister.Password)
	if err != nil {
		log.Println(err)
		return domain.UserInfo{
			Present: false,
		}
	}
	userRegister.Password = encryptPassword
	savedUser, err := userServiceImpl.UserRepository.RegisterUser(userRegister)
	if err != nil {
		log.Println(err)
		return domain.UserInfo{
			Present: false,
		}
	}
	userInfo := domain.CreateUserInfo(savedUser)
	return userInfo
}
```
- User Api error check
```go
func RegisterUser(c *gin.Context) {
	var userRegister domain.UserRegister
	result := domain.Success()
	if err := c.BindJSON(&userRegister); err != nil {
		result = domain.Fail()
		result.Data = err
		c.JSON(500, result)
	}
	data := application.UserServiceBean.RegisterUser(userRegister)
	result.Data = data
	c.JSON(200, result)
}
```
### 변경후
- RegisterUser
```go
func (userServiceImpl *UserServiceImpl) RegisterUser(userRegister domain.UserRegister) domain.UserInfo {
	_, err := userServiceImpl.UserRepository.FindUser(userRegister.Email)
	if err == nil {
		return domain.UserInfo{
			Present: false,
		}
	}

	encryptPassword, err := util.GenerateBcrypt(userRegister.Password)
	if err != nil {
		log.Println(err)
		return domain.UserInfo{
			Present: false,
		}
	}
	userRegister.Password = encryptPassword
	savedUser, err := userServiceImpl.UserRepository.RegisterUser(userRegister)
	if err != nil {
		log.Println(err)
		return domain.UserInfo{
			Present: false,
		}
	}
	userInfo := domain.CreateUserInfo(savedUser)
	return userInfo
}
```
- User Api error check
```go
func RegisterUser(c *gin.Context) {
	var userRegister domain.UserRegister
	result := domain.Success()
	if err := c.BindJSON(&userRegister); err != nil {
		result = domain.Fail()
		result.Data = err
		c.JSON(500, result)
	}
	data := application.UserServiceBean.RegisterUser(userRegister)
	if data.Present == false {
		c.JSON(500, errors.New("user register fail"))
	}
	result.Data = data
	c.JSON(200, result)
}
```
## 사용방법
## 기타
